### PR TITLE
restructure config to support auth methods

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -6,11 +6,29 @@ from typing import Any, Callable
 import requests
 from flask import Flask, Response, jsonify, request, send_from_directory
 
+from app.auth import UnauthorizedUser
 from app.utils import CombinedConfig, MainConfig, RegionConfig, load_config
 
 app = Flask(__name__)
 
 config = load_config()
+
+
+def authenticate_request(f: Callable[..., Response]) -> Callable[..., Response]:
+    @wraps(f)
+    def authenticate(*args: Any, **kwargs: Any) -> Response:
+        data = request.get_json()
+
+        try:
+            config.auth.authenticate_request(request)
+        except UnauthorizedUser:
+            err_response = jsonify({"error": "Unauthorized"})
+            err_response.status_code = 401
+            return err_response
+        res = f(*args, **kwargs)
+        return res
+
+    return authenticate
 
 
 def cache_static_files(f: Callable[..., Response]) -> Callable[..., Response]:
@@ -82,6 +100,7 @@ if not isinstance(config, RegionConfig):
         return send_from_directory("frontend/dist/assets", filename)
 
     @app.route("/run", methods=["POST"])
+    @authenticate_request
     def run_all() -> Response:
         """
         Run a script for all regions
@@ -138,6 +157,7 @@ if not isinstance(config, RegionConfig):
 if not isinstance(config, MainConfig):
 
     @app.route("/run_region", methods=["POST"])
+    @authenticate_request
     def run_one_region() -> Response:
         """
         Run a script for a specific region. Called from the `/run` endpoint.

--- a/app/app.py
+++ b/app/app.py
@@ -17,8 +17,6 @@ config = load_config()
 def authenticate_request(f: Callable[..., Response]) -> Callable[..., Response]:
     @wraps(f)
     def authenticate(*args: Any, **kwargs: Any) -> Response:
-        data = request.get_json()
-
         try:
             config.auth.authenticate_request(request)
         except UnauthorizedUser:

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,31 @@
+from abc import abstractmethod
+from flask import Request
+
+
+class UnauthorizedUser(Exception):
+    pass
+
+
+class AuthMethod:
+    @abstractmethod
+    def authenticate_request(self, request: Request) -> None:
+        """
+        Raise UnauthorizedUser exception if the request cannot be authenticated.
+        """
+        raise NotImplementedError
+
+
+class GoogleAuth(AuthMethod):
+    def __init__(self, audience: str, iap_principals: dict[str, list[str]]):
+        self.audience = audience
+        self.iap_principals: dict[str, list[str]] = iap_principals
+
+    def authenticate_request(self, request: Request) -> None:
+        # TODO: Implement the authentication logic
+        pass
+
+
+class NoAuth(AuthMethod):
+    def authenticate_request(self, request: Request) -> None:
+        # No authentication required
+        pass

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+
 from flask import Request
 
 

--- a/app/config.schema.json
+++ b/app/config.schema.json
@@ -2,82 +2,142 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Config schema",
   "type": "object",
-    "properties": {
-      "mode": {
-        "enum": ["combined", "main", "region"]
-      },
-      "groups": {
-        "additionalProperties": {
-          "type": "object",
-          "properties": {
-            "python_module": {
-              "type": "string"
-            },
-            "iap_principals": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "required": ["python_module", "iap_principals"]
-        }
-      },
-      "main": {
+  "properties": {
+    "mode": {
+      "enum": [
+        "combined",
+        "main",
+        "region"
+      ]
+    },
+    "groups": {
+      "additionalProperties": {
         "type": "object",
         "properties": {
-          "regions": {
-            "type": "array",
-            "items": {
+          "python_module": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "python_module"
+        ]
+      }
+    },
+    "authentication": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": [
+            "no_auth",
+            "google_iap"
+          ]
+        },
+        "additionalProperties": false,
+        "google_iap": {
+          "type": "object",
+          "properties": {
+            "iap_principals": {
               "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "url": {
+              "additionalProperties": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 }
               }
-            }
-          }
+            },
+            "additionalProperties": false
+          },
+          "additionalProperties": false
         }
       },
-      "region": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "required": [
+        "method"
+      ],
+      "dependencies": {
+        "google_iap": {
+          "properties": {
+            "method": {
+              "const": "google_iap"
+            }
           },
-          "configs": {
-            "type": "object"
+          "required": [
+            "google_iap"
+          ]
+        }
+      }
+    },
+    "main": {
+      "type": "object",
+      "properties": {
+        "regions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
           }
         }
       }
     },
-    "required": ["mode", "groups"],
-    "dependencies": {
-      "mode": {
-        "oneOf": [
-          {
-            "properties": {
-              "mode": {"const": "combined"}
-            },
-            "required": ["main", "region"]
-          },
-          {
-            "properties": {
-              "mode": {"const": "main"}
-            },
-            "required": ["main"]
-          },
-          {
-            "properties": {
-              "mode": {"const": "region"}
-            },
-            "required": ["region"]
-          }
-        ]
+    "region": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "configs": {
+          "type": "object"
+        }
       }
     }
-
+  },
+  "required": [
+    "mode",
+    "groups"
+  ],
+  "dependencies": {
+    "mode": {
+      "oneOf": [
+        {
+          "properties": {
+            "mode": {
+              "const": "combined"
+            }
+          },
+          "required": [
+            "main",
+            "region"
+          ]
+        },
+        {
+          "properties": {
+            "mode": {
+              "const": "main"
+            }
+          },
+          "required": [
+            "main"
+          ]
+        },
+        {
+          "properties": {
+            "mode": {
+              "const": "region"
+            }
+          },
+          "required": [
+            "region"
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/app/utils.py
+++ b/app/utils.py
@@ -9,10 +9,11 @@ from enum import Enum
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Literal
-from app.auth import AuthMethod, NoAuth, GoogleAuth
 
 import jsonschema
 import yaml
+
+from app.auth import AuthMethod, GoogleAuth, NoAuth
 
 
 class ConfigError(Exception):

--- a/example_config_combined.yaml
+++ b/example_config_combined.yaml
@@ -2,16 +2,19 @@ mode: combined
 groups:
   kafka:
     python_module: examples.scripts.kafka
-    iap_principals:
-      - team-ops@sentry.io
-      - team-streaming@sentry.io
   access_logs:
     python_module: examples.scripts.access_logs
-    iap_principals:
-      - team-ops@sentry.io
   example:
     python_module: examples.scripts.example
-    iap_principals: []
+authentication:
+  method: google_iap
+  google_iap:
+    iap_principals:
+      kafka:
+        - team-ops@sentry.io
+        - team-streaming-platform@sentry.io
+      access_logs:
+        - team-ops@sentry.io
 main:
   regions:
     - name: s4s
@@ -21,9 +24,9 @@ region:
   configs:
     kafka:
       clusters:
-      - name: local
-        brokers:
-          - localhost:9092
+        - name: local
+          brokers:
+            - localhost:9092
     access_logs:
       host: localhost
       port: 9000

--- a/example_config_main.yaml
+++ b/example_config_main.yaml
@@ -2,17 +2,13 @@ mode: main
 groups:
   kafka:
     python_module: examples.scripts.kafka
-    iap_principals:
-    - team-ops@sentry.io
-    - team-streaming@sentry.io
   access_logs:
     python_module: examples.scripts.access_logs
-    iap_principals: []
   example:
     python_module: examples.scripts.example
-    iap_principals: []
 main:
   regions:
     - name: s4s
       url: localhost:5002
-
+authentication:
+  method: no_auth

--- a/example_config_s4s.yaml
+++ b/example_config_s4s.yaml
@@ -2,25 +2,22 @@ mode: region
 groups:
   kafka:
     python_module: examples.scripts.kafka
-    iap_principals:
-    - team-ops@sentry.io
-    - team-streaming@sentry.io
   access_logs:
     python_module: examples.scripts.access_logs
-    iap_principals: []
   example:
     python_module: examples.scripts.example
-    iap_principals: []
 region:
   name: s4s
   configs:
     kafka:
       clusters:
-      - name: local
-        brokers:
-          - localhost:9092
+        - name: local
+          brokers:
+            - localhost:9092
     access_logs:
       host: localhost
       port: 9000
       database: clicktail
       table_name: access_log_local
+authentication:
+  method: no_auth

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,28 @@
-from app.utils import FunctionParameter, load_group
+from app.utils import FunctionParameter, load_group, CommonFields
+from app.auth import GoogleAuth, NoAuth
+
+
+def test_common_fields() -> None:
+    no_auth = CommonFields.from_dict(
+        {
+            "groups": {},
+            "authentication": {
+                "method": "no_auth",
+            },
+        }
+    )
+    assert isinstance(no_auth.auth, NoAuth)
+
+    google_auth = CommonFields.from_dict(
+        {
+            "groups": {"example": {"python_module": "tests.example"}},
+            "authentication": {
+                "method": "google_iap",
+                "google_iap": {"iap_principals": {"example": ["test@test.com"]}},
+            },
+        }
+    )
+    assert isinstance(google_auth.auth, GoogleAuth)
 
 
 def test_validate_config_functions() -> None:
@@ -7,11 +31,9 @@ def test_validate_config_functions() -> None:
     """
     module = "tests.example"
     group_name = "example"
-    iap_principals = ["test@sentry.io"]
 
-    group = load_group(module, group_name, iap_principals)
+    group = load_group(module, group_name)
     assert group.module == module
-    assert group.iap_principals == ["test@sentry.io"]
     assert [f.name for f in group.functions] == ["hello", "hello_with_enum"]
     assert [f.parameters for f in group.functions] == [
         [FunctionParameter(name="to", default="world", enumValues=None)],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
-from app.utils import FunctionParameter, load_group, CommonFields
 from app.auth import GoogleAuth, NoAuth
+from app.utils import CommonFields, FunctionParameter, load_group
 
 
 def test_common_fields() -> None:


### PR DESCRIPTION
restructures the config so multiple auth methods can be supported and it is easy to add more.
google_iap and no_auth are defined as the 2 supported methods now.