### PR TITLE
build: remove hardcoded python version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with:
-          python-version: |
-            3.12
       - run: |
           pip install build
           python -m build


### PR DESCRIPTION
let's not set this here, github will respect the version specified in `.python-version`