### PR TITLE
a better function api

### DIFF
--- a/examples/scripts/example/__init__.py
+++ b/examples/scripts/example/__init__.py
@@ -1,9 +1,9 @@
-from typing import Any, Literal
+from typing import Literal
 from script_runner import read, write
 
 
 @read
-def hello(config: Any, to: str = "world") -> str:
+def hello(to: str = "world") -> str:
     """
     This function says hello to someone
     """
@@ -11,7 +11,7 @@ def hello(config: Any, to: str = "world") -> str:
 
 
 @read
-def hello_with_enum(config: Any, to: Literal["foo", "bar"] = "foo") -> str:
+def hello_with_enum(to: Literal["foo", "bar"] = "foo") -> str:
     """
     Demo of literal type + default value
     """
@@ -19,7 +19,7 @@ def hello_with_enum(config: Any, to: Literal["foo", "bar"] = "foo") -> str:
 
 
 @write
-def writes_to_file(config: Any, content: str) -> None:
+def writes_to_file(content: str) -> None:
     with open("example.txt", "w") as file:
         file.write(content)
 

--- a/examples/scripts/example_no_access/__init__.py
+++ b/examples/scripts/example_no_access/__init__.py
@@ -1,9 +1,8 @@
-from typing import Any
 from script_runner import read
 
 
 @read
-def do_stuff(config: dict[str, Any]):
+def do_stuff():
     print("Doing stuff")
 
 

--- a/script_runner/__init__.py
+++ b/script_runner/__init__.py
@@ -1,3 +1,4 @@
 from script_runner.function import read, write
+from script_runner.context import get_function_context
 
-__all__ = ["read", "write"]
+__all__ = ["read", "write", "get_function_context"]

--- a/script_runner/__init__.py
+++ b/script_runner/__init__.py
@@ -1,4 +1,4 @@
-from script_runner.function import read, write
 from script_runner.context import get_function_context
+from script_runner.function import read, write
 
 __all__ = ["read", "write", "get_function_context"]

--- a/script_runner/app.py
+++ b/script_runner/app.py
@@ -13,7 +13,6 @@ from script_runner.context import function_context_thread_local
 from script_runner.function import WrappedFunction
 from script_runner.utils import CombinedConfig, MainConfig, RegionConfig, load_config
 
-
 config = load_config()
 
 if config.sentry_dsn:

--- a/script_runner/app.py
+++ b/script_runner/app.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 
 import requests
 import sentry_sdk
-from flask import Flask, Response, jsonify, request, send_from_directory, g
+from flask import Flask, Response, g, jsonify, request, send_from_directory
 
 from script_runner.auth import UnauthorizedUser
 from script_runner.function import WrappedFunction

--- a/script_runner/app.py
+++ b/script_runner/app.py
@@ -6,10 +6,9 @@ from typing import Any, Callable
 
 import requests
 import sentry_sdk
-from flask import Flask, Response, jsonify, request, send_from_directory
+from flask import Flask, Response, jsonify, request, send_from_directory, g
 
 from script_runner.auth import UnauthorizedUser
-from script_runner.context import function_context_thread_local
 from script_runner.function import WrappedFunction
 from script_runner.utils import CombinedConfig, MainConfig, RegionConfig, load_config
 
@@ -207,6 +206,6 @@ if not isinstance(config, MainConfig):
         func = getattr(module, requested_function)
         assert isinstance(func, WrappedFunction)
         group_config = config.region.configs.get(group_name, None)
-        function_context_thread_local.region = data["region"]
-        function_context_thread_local.group_config = group_config
+        g.region = data["region"]
+        g.group_config = group_config
         return jsonify(func.func(*params))

--- a/script_runner/context.py
+++ b/script_runner/context.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Generic, TypeVar
-from flask import g
 
+from flask import g
 
 T = TypeVar("T")
 

--- a/script_runner/context.py
+++ b/script_runner/context.py
@@ -1,0 +1,25 @@
+import threading
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+function_context_thread_local = threading.local()
+
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class FunctionContext(Generic[T]):
+    region: str
+    group_config: T
+
+
+def get_function_context() -> FunctionContext[T]:
+    """
+    Returns the function context for the current thread.
+    This is used to access the region and group config.
+    """
+    return FunctionContext(
+        region=function_context_thread_local.region,
+        group_config=function_context_thread_local.group_config,
+    )

--- a/script_runner/context.py
+++ b/script_runner/context.py
@@ -1,8 +1,6 @@
-import threading
 from dataclasses import dataclass
 from typing import Generic, TypeVar
-
-function_context_thread_local = threading.local()
+from flask import g
 
 
 T = TypeVar("T")
@@ -20,6 +18,6 @@ def get_function_context() -> FunctionContext[T]:
     This is used to access the region and group config.
     """
     return FunctionContext(
-        region=function_context_thread_local.region,
-        group_config=function_context_thread_local.group_config,
+        region=g.region,
+        group_config=g.group_config,
     )

--- a/script_runner/utils.py
+++ b/script_runner/utils.py
@@ -215,8 +215,6 @@ def load_group(module_name: str, group: str) -> FunctionGroup:
 
         source = inspect.getsource(function.func)
         sig = inspect.signature(function.func)
-        parameters = [p for p in sig.parameters]
-        assert parameters[0] == "config", f"First parameter of {f} must be 'config'"
 
         functions.append(
             Function(
@@ -234,17 +232,12 @@ def load_group(module_name: str, group: str) -> FunctionGroup:
                         enumValues=get_enum_values(v.annotation),
                     )
                     for (k, v) in sig.parameters.items()
-                    if k != "config"
                 ],
                 is_readonly=function.is_readonly,
             )
         )
 
-    return FunctionGroup(
-        group=group,
-        module=module_name,
-        functions=functions,
-    )
+    return FunctionGroup(group=group, module=module_name, functions=functions)
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/example/__init__.py
+++ b/tests/example/__init__.py
@@ -1,10 +1,10 @@
-from typing import Any, Literal
+from typing import Literal
 
 from script_runner import read, write
 
 
 @read
-def hello(config: Any, to: str = "world") -> str:
+def hello(to: str = "world") -> str:
     """
     This function says hello to someone
     """
@@ -12,7 +12,7 @@ def hello(config: Any, to: str = "world") -> str:
 
 
 @read
-def hello_with_enum(config: Any, to: Literal["foo", "bar"] = "foo") -> str:
+def hello_with_enum(to: Literal["foo", "bar"] = "foo") -> str:
     """
     Demo of literal type + default value
     """
@@ -20,7 +20,7 @@ def hello_with_enum(config: Any, to: Literal["foo", "bar"] = "foo") -> str:
 
 
 @write
-def some_write_function(config: Any) -> None:
+def some_write_function() -> None:
     pass
 
 

--- a/tests/invalid_example/__init__.py
+++ b/tests/invalid_example/__init__.py
@@ -1,7 +1,4 @@
-from typing import Any
-
-
-def no_decorator(config: Any) -> None:
+def no_decorator() -> None:
     pass
 
 


### PR DESCRIPTION
previously user scripts needed to take `config` as a first argument, and they were passed any relevant region/group specific config (for example the list of kafka brokers). now we also want to pass the `region` in. this revealed a problem with the previous api, as it was not easy to modify in a backward-compatible way. now functions take no config argument. instead they have access to a context object that contains just the region and the group config. this can also be extended in the future if we want to add properties here in a backward compatible way which requires no changes to existing functions.