### PR TITLE
adjust the files in the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 .DS_Store
 *.log
 .pytest_cache
+*.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,2 @@
-graft script_runner/frontend
-
-prune script_runner/frontend/node_modules
-
+include LICENSE
 include py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 [build-system]
-
 requires = ["setuptools>=78.1.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
@@ -21,7 +20,8 @@ dynamic = ["dependencies"]
 dependencies = { file = ["requirements.txt"] }
 
 [tool.setuptools]
-include-package-data = true
+include-package-data = false
+packages = ["script_runner"]
 
 [tool.setuptools.package-data]
 script_runner = ["config.schema.json", "frontend/dist/**/*"]


### PR DESCRIPTION
- specify only the `script_runner` package to be included as we do not need the tests and examples to be there
- instead of including all frontend files by default then removing some, this only only includes the built dist files and everything else is omitted by default
- add license to package