### PR TITLE
add github as release target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -6,6 +6,7 @@ changelogPolicy: auto
 preReleaseCommand: bash ./bin/bump-version.sh
 releaseBranchPrefix: release
 targets:
+  - name: github
   - name: pypi
   - name: sentry-pypi
     internalPypiRepo: getsentry/pypi


### PR DESCRIPTION
it's a bit weird that the only one release on github was 0.0.1 let's keep this up to date too