### PR TITLE
pass the right args to get_group_membership

### DIFF
--- a/script_runner/auth.py
+++ b/script_runner/auth.py
@@ -104,7 +104,7 @@ class GoogleAuth(AuthMethod):
         """
         epoch_day = int(time.time()) // 86400  # 1 day = 86400 seconds
 
-        members = self.__get_group_membership(user_email, group_email, epoch_day)
+        members = self.__get_group_membership(group_email, epoch_day)
 
         if user_email in members:
             return True


### PR DESCRIPTION
mypy should have complained, unfortunately the lru_cache seems like it prevented that