### PR TITLE
fix kafka module: confluent kafka requires this to be a dict

### DIFF
--- a/examples/scripts/kafka/kafka.py
+++ b/examples/scripts/kafka/kafka.py
@@ -25,7 +25,7 @@ class KafkaConfig(TypedDict):
     clusters: list[KafkaCluster]
 
 
-class HashableConfig(UserDict[str, str]):
+class HashableConfig(dict[str, str]):
     def __hash__(self) -> int:
         return hash(tuple(sorted(self.items())))
 


### PR DESCRIPTION
it will throw a TypeError and fail to make any queries if we use UserDict