### PR TITLE
validation: check all functions have string args on startup

### DIFF
--- a/examples/scripts/access_logs/__init__.py
+++ b/examples/scripts/access_logs/__init__.py
@@ -3,11 +3,17 @@ Supports read queries on the acccess logs table
 """
 
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, TypedDict
 
 from clickhouse_driver import Client
 
-from script_runner import read
+from script_runner import read, get_function_context
+
+class AccessLogsConfig(TypedDict):
+    host: str
+    port: int
+    database: str
+    table_name: str
 
 
 def get_date_n_days_ago(n: int) -> str:
@@ -23,7 +29,6 @@ def get_date_n_days_ago(n: int) -> str:
 
 @read
 def response_code_by_time(
-    config: Any,
     request_uri_path: str = "/api/0/organizations/sentry/events/",
     status_code: str = "400",
     num_days: str = "7",
@@ -32,6 +37,9 @@ def response_code_by_time(
     Returns the breakdown of response codes by time.
     `status_code` must be a valid integer
     """
+
+    config: AccessLogsConfig = get_function_context().group_config
+
     status_code_int = int(status_code)
     num_days_int = int(num_days)
 

--- a/examples/scripts/access_logs/__init__.py
+++ b/examples/scripts/access_logs/__init__.py
@@ -7,7 +7,8 @@ from typing import Any, TypedDict
 
 from clickhouse_driver import Client
 
-from script_runner import read, get_function_context
+from script_runner import get_function_context, read
+
 
 class AccessLogsConfig(TypedDict):
     host: str

--- a/examples/scripts/example/__init__.py
+++ b/examples/scripts/example/__init__.py
@@ -1,5 +1,5 @@
 """
-The hello world example
+Script runner demos
 """
 
 from typing import Literal
@@ -25,6 +25,10 @@ def hello_with_enum(to: Literal["foo", "bar"] = "foo") -> str:
 
 @write
 def writes_to_file(content: str) -> None:
+    """
+    Testing a write action
+    """
+
     with open("example.txt", "w") as file:
         file.write(content)
 

--- a/examples/scripts/kafka/kafka.py
+++ b/examples/scripts/kafka/kafka.py
@@ -1,5 +1,4 @@
 import functools
-from collections import UserDict
 from typing import Any, TypedDict
 
 from confluent_kafka import (

--- a/script_runner/app_blueprint.py
+++ b/script_runner/app_blueprint.py
@@ -213,4 +213,4 @@ if not isinstance(config, MainConfig):
         group_config = config.region.configs.get(group_name, None)
         g.region = data["region"]
         g.group_config = group_config
-        return jsonify(func.func(*params))
+        return jsonify(func(*params))

--- a/script_runner/function.py
+++ b/script_runner/function.py
@@ -1,5 +1,5 @@
-from typing import Any, Callable, Literal
 import inspect
+from typing import Any, Callable, Literal
 
 RawFunction = Callable[..., Any]
 

--- a/script_runner/function.py
+++ b/script_runner/function.py
@@ -19,7 +19,6 @@ class WrappedFunction:
                 continue
             raise TypeError(f"{func} has non-string argument {param.name}")
 
-
     @property
     def is_readonly(self) -> bool:
         return self._readonly

--- a/script_runner/testutils.py
+++ b/script_runner/testutils.py
@@ -17,4 +17,4 @@ def execute_with_context(
         g.region = mock_context.region
         g.group_config = mock_context.group_config
 
-        return func.func(*args)
+        return func(*args)


### PR DESCRIPTION
script-runner only support passing args as strings. this enforces that on startup now.