### PR TITLE
fix style for long text in nav

### DIFF
--- a/script_runner/frontend/src/App.css
+++ b/script_runner/frontend/src/App.css
@@ -218,6 +218,9 @@ li.home-search-result:hover {
   font-size: 14px;
   margin-left: 25px;
   display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .nav-function.active {


### PR DESCRIPTION
long function names were breaking the layout before, we should truncate these so they don't break across multiple lines