### PR TITLE
render documentation in the UI

### DIFF
--- a/examples/scripts/example/README.md
+++ b/examples/scripts/example/README.md
@@ -1,0 +1,5 @@
+## Example scripts
+
+This module contains some demo examples, not intended for production.
+
+`script-runner` is a library -- use it with your own scripts!

--- a/script_runner/app_blueprint.py
+++ b/script_runner/app_blueprint.py
@@ -75,6 +75,11 @@ def get_config() -> dict[str, Any]:
                 }
                 for f in function_group.functions
             ],
+            "docstring": function_group.docstring,
+            "markdownFiles": [
+                {"name": file.filename, "content": file.content}
+                for file in function_group.markdown_files
+            ],
         }
         for (g, function_group) in groups.items()
     ]

--- a/script_runner/frontend/package-lock.json
+++ b/script_runner/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "ag-grid-community": "^33.1.1",
         "ag-grid-react": "^33.1.1",
         "jq-web": "^0.6.1",
+        "marked": "^15.0.11",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-syntax-highlighter": "^15.6.1"
@@ -2717,6 +2718,17 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.11",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.11.tgz",
+      "integrity": "sha512-1BEXAU2euRCG3xwgLVT1y0xbJEld1XOrmRJpUwRCcy7rxhSCwMrmEu9LXoPhHSCJG41V7YcQ2mjKRr5BA3ITIA==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/merge2": {

--- a/script_runner/frontend/package.json
+++ b/script_runner/frontend/package.json
@@ -16,6 +16,7 @@
     "ag-grid-community": "^33.1.1",
     "ag-grid-react": "^33.1.1",
     "jq-web": "^0.6.1",
+    "marked": "^15.0.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-syntax-highlighter": "^15.6.1"

--- a/script_runner/frontend/src/App.css
+++ b/script_runner/frontend/src/App.css
@@ -217,7 +217,8 @@ li.home-search-result:hover {
   font-family: var(--font-mono);
   font-size: 14px;
   margin-left: 25px;
-  display: block;
+  display: flex;
+  align-items: center;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -225,6 +226,10 @@ li.home-search-result:hover {
 
 .nav-function.active {
   color: var(--highlight-text);
+}
+
+.document-markdown {
+  padding: 10px;
 }
 
 .function-header {

--- a/script_runner/frontend/src/App.tsx
+++ b/script_runner/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Nav from './Nav.tsx'
 import { Config, Route } from './types.tsx'
 import Header from './Header.tsx'
 import NotFound from './NotFound.tsx'
+import Document from './Document.tsx'
 import Api from './api.tsx'
 
 function App() {
@@ -135,6 +136,11 @@ function App() {
       const functionDef = group.functions.find(f => f.name == route.function);
 
       if (!functionDef) {
+        const markdownDef = group.markdownFiles.find(f => f.name == route.function);
+        if (markdownDef) {
+          return <Document name={markdownDef.name} content={markdownDef.content} />
+        }
+
         return <NotFound />
       }
 

--- a/script_runner/frontend/src/Document.tsx
+++ b/script_runner/frontend/src/Document.tsx
@@ -1,0 +1,19 @@
+import { marked } from 'marked';
+
+interface Props {
+  name: string;
+  content: string;
+}
+
+function Document(props: Props) {
+  return <div>
+    <div
+      className="document-markdown"
+      dangerouslySetInnerHTML={{ __html: marked(props.content) }}
+    />
+
+  </div>
+
+}
+
+export default Document;

--- a/script_runner/frontend/src/Nav.tsx
+++ b/script_runner/frontend/src/Nav.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import "./App.css";
 import { ConfigGroup, Route } from "./types.tsx";
-import { FolderPlusIcon, FolderMinusIcon } from "@heroicons/react/24/outline";
+import { FolderPlusIcon, FolderMinusIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
 import Tag from "./Tag";
 
 interface Props {
@@ -61,15 +61,19 @@ function Nav(props: Props) {
               </div>
               {isExpanded && (
                 <div>
+                  {group.markdownFiles.map((file) => <a className={`nav-function ${file.name === activeFunction && group.group === activeGroup
+                    ? "active"
+                    : ""
+                    }`} onClick={() => { props.navigate({ regions: props.route.regions, group: group.group, function: file.name }) }}>
+                    <span className="nav-group-icon"><DocumentTextIcon /></span>{file.name}</a>)}
                   {group.functions.map((f) => (
                     <a
                       key={f.name}
                       title={f.name}
-                      className={`nav-function ${
-                        f.name === activeFunction && group.group === activeGroup
-                          ? "active"
-                          : ""
-                      }`}
+                      className={`nav-function ${f.name === activeFunction && group.group === activeGroup
+                        ? "active"
+                        : ""
+                        }`}
                       onClick={() =>
                         props.navigate({
                           regions: props.route.regions,

--- a/script_runner/frontend/src/types.tsx
+++ b/script_runner/frontend/src/types.tsx
@@ -14,10 +14,16 @@ export interface ConfigFunction {
   isReadonly: boolean;
 }
 
+export interface MarkdownFile {
+  name: string,
+  content: string;
+}
+
 export interface ConfigGroup {
   group: string;
   functions: ConfigFunction[];
   docstring: string;
+  markdownFiles: MarkdownFile[];
 }
 
 export interface Config {


### PR DESCRIPTION
we added documentation for the kafka module (https://github.com/getsentry/sentry-scripts/pull/59)

so.. may as well render it all in the UI if any markdown files are present in a group

this is what it looks like

<img width="1182" alt="Screenshot 2025-04-30 at 4 03 45 pm" src="https://github.com/user-attachments/assets/94eda776-eeed-4f29-9a5c-94704c99462e" />
