### PR TITLE
custom function parameters and input types

### DIFF
--- a/examples/scripts/example/__init__.py
+++ b/examples/scripts/example/__init__.py
@@ -4,35 +4,41 @@ Script runner demos
 
 import random
 from datetime import datetime, timedelta
-from typing import Literal
 
-from script_runner import read, write
+from script_runner import Integer, Number, Select, Text, TextArea, read, write
 
 
 @read
-def hello(to: str = "world") -> str:
+def hello(to: Text = Text(default="world")) -> str:
     """
     This function says hello to someone
     """
-    return f"hello {to}"
+    return f"hello {to.value}"
 
 
 @read
-def hello_with_enum(to: Literal["foo", "bar"] = "foo") -> str:
+def hello_with_enum(to: Select = Select(options=["foo", "bar"], default="foo")) -> str:
     """
     Demo of literal type + default value
     """
-    return f"hello {to}"
+    return f"hello {to.value}"
+
+
+@read
+def add_numbers(a: Integer, b: Number = Number(default=0.1)) -> float:
+    """
+    testing numeric input types
+    """
+    return float(a.value) + b.value
 
 
 @write
-def writes_to_file(content: str) -> None:
+def writes_to_file(content: TextArea) -> None:
     """
     Testing a write action
     """
-
     with open("example.txt", "w") as file:
-        file.write(content)
+        file.write(content.value)
 
 
 @read
@@ -51,4 +57,4 @@ def render_chart() -> list[dict[str, str | int]]:
     )
 
 
-__all__ = ["hello", "hello_with_enum", "writes_to_file", "render_chart"]
+__all__ = ["hello", "hello_with_enum", "writes_to_file", "render_chart", "add_numbers"]

--- a/script_runner/__init__.py
+++ b/script_runner/__init__.py
@@ -1,4 +1,22 @@
 from script_runner.context import get_function_context
 from script_runner.function import read, write
+from script_runner.function_parameter import (
+    FunctionParameter,
+    Integer,
+    Number,
+    Select,
+    Text,
+    TextArea,
+)
 
-__all__ = ["read", "write", "get_function_context"]
+__all__ = [
+    "read",
+    "write",
+    "get_function_context",
+    "FunctionParameter",
+    "Text",
+    "TextArea",
+    "Number",
+    "Integer",
+    "Select",
+]

--- a/script_runner/app_blueprint.py
+++ b/script_runner/app_blueprint.py
@@ -66,8 +66,9 @@ def get_config() -> dict[str, Any]:
                     "parameters": [
                         {
                             "name": p.name,
+                            "type": p.type.value,
                             "default": p.default,
-                            "enumValues": p.enumValues,
+                            "enumValues": p.enum_values,
                         }
                         for p in f.parameters
                     ],

--- a/script_runner/frontend/src/Script.tsx
+++ b/script_runner/frontend/src/Script.tsx
@@ -103,7 +103,7 @@ function Script(props: Props) {
                         <label htmlFor={arg.name}>{arg.name}</label>
                       </div>
                       <div>
-                        {arg.enumValues && (
+                        {arg.type == "select" && (
                           <select
                             id={arg.name}
                             required
@@ -114,12 +114,12 @@ function Script(props: Props) {
                             }
                           >
                             <option value="">Select...</option>
-                            {arg.enumValues.map((v) => (
+                            {arg.enumValues!.map((v) => (
                               <option value={v}>{v}</option>
                             ))}
                           </select>
                         )}
-                        {!arg.enumValues && (
+                        {arg.type == "text" && (
                           <input
                             type="text"
                             id={arg.name}
@@ -131,6 +131,51 @@ function Script(props: Props) {
                             disabled={disabled}
                           />
                         )}
+                        {arg.type == "textarea" && (
+                          <textarea
+                            id={arg.name}
+                            value={params[idx] || ""}
+                            onChange={(e) =>
+                              handleInputChange(idx, e.target.value)
+                            }
+                            required
+                            disabled={disabled}
+                          />
+                        )}
+                        {arg.type == "integer" && (
+                          <input
+                            type="number"
+                            id={arg.name}
+                            value={Number(params[idx]) || 0}
+                            onChange={(e) => {
+                              console.log(e.target.value)
+                              if (!Number.isInteger(e.target.valueAsNumber)) {
+                                setError("invalid integer")
+                                return;
+                              }
+                              handleInputChange(idx, e.target.value)
+                            }}
+                            required
+                            disabled={disabled}
+                          />
+                        )}
+                        {arg.type == "number" && (
+                          <input
+                            type="number"
+                            id={arg.name}
+                            value={Number(params[idx]) || 0}
+                            onChange={(e) => {
+                              if (isNaN(e.target.valueAsNumber)) {
+                                setError("Invalid number");
+                                return;
+                              }
+                              handleInputChange(idx, e.target.value)
+                            }}
+                            required
+                            disabled={disabled}
+                          />
+                        )}
+
                       </div>
                     </div>
                   );

--- a/script_runner/frontend/src/types.tsx
+++ b/script_runner/frontend/src/types.tsx
@@ -3,6 +3,7 @@ export type RunResult = { [region: string]: unknown };
 export type ConfigParam = {
   name: string;
   default: string | null;
+  type: 'text' | 'textarea' | 'select' | 'number' | 'integer';
   enumValues: string[] | null;
 };
 

--- a/script_runner/function.py
+++ b/script_runner/function.py
@@ -1,30 +1,42 @@
+import copy
 import inspect
-from typing import Any, Callable, Literal
+from typing import Any, Callable
+
+from script_runner.function_parameter import FunctionParameter
 
 RawFunction = Callable[..., Any]
 
 
 class WrappedFunction:
     def __init__(self, func: RawFunction, readonly: bool) -> None:
-        self.func = func
+        self._func = func
         self._readonly = readonly
 
-        # Validate raw function
-        for param in inspect.signature(func).parameters.values():
-            if param.annotation is str:
+        self._params: list[tuple[str, FunctionParameter[Any]]] = []
+
+        # Validate function arguments
+        for name, param in inspect.signature(func).parameters.items():
+            if issubclass(param.annotation, FunctionParameter):
+                if param.default is inspect.Parameter.empty:
+                    self._params.append((name, param.annotation()))
+                else:
+                    self._params.append((name, param.default))
                 continue
-            elif param.annotation.__origin__ == Literal and all(
-                [isinstance(a, str) for a in param.annotation.__args__]
-            ):
-                continue
-            raise TypeError(f"{func} has non-string argument {param.name}")
+            raise TypeError(f"{func.__name__} has invalid argument {param.name}")
 
     @property
     def is_readonly(self) -> bool:
         return self._readonly
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        return self.func(*args, **kwargs)
+    def __call__(self, *args: Any) -> Any:
+        # Deep copy the parameters on each function execution becuase we use
+        # mutable default arguments in function signatures.
+        params = [copy.deepcopy(p[1]) for p in self._params]
+
+        for idx, arg in enumerate(args):
+            params[idx].set_value(arg)
+
+        return self._func(*params)
 
 
 def read(func: RawFunction) -> WrappedFunction:

--- a/script_runner/function_parameter.py
+++ b/script_runner/function_parameter.py
@@ -1,0 +1,144 @@
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Generic, TypeVar
+
+
+# This is the list of types that the UI knows how to handle
+class InputType(Enum):
+    TEXT = "text"  # <input type=text />
+    TEXTAREA = "textarea"  # <textarea />
+    SELECT = "select"  # <select />
+    NUMBER = "number"  # <input type=number />
+    INTEGER = "integer"  # <input type=number /> with integer validation
+
+
+TParam = TypeVar("TParam", int, float, str, bool)
+
+
+class FunctionParameter(ABC, Generic[TParam]):
+    @abstractmethod
+    def input_type(self) -> InputType:
+        raise NotImplementedError
+
+    @abstractmethod
+    def encode(self, value: TParam) -> str:
+        """
+        values are always strings in the API/UI
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def decode(self, value: str) -> TParam:
+        """
+        decode values from the UI
+        input validation can be done here
+        """
+        raise NotImplementedError
+
+    def set_value(self, value: str) -> None:
+        """
+        Initially empty. self._value is populated
+        when the value gets set via the UI
+        """
+        self._value: TParam = self.decode(value)
+
+    def set_default(self, default: TParam) -> None:
+        """
+        Called from constructor of of the subclass to set the default value
+        if one is provided
+        """
+        self._default: TParam = default
+
+    @property
+    def value(self) -> TParam:
+        if hasattr(self, "_value"):
+            return self._value
+        elif hasattr(self, "_default"):
+            return self._default
+        else:
+            raise ValueError("No value or default")
+
+    @property
+    def default(self) -> TParam | None:
+        return getattr(self, "_default", None)
+
+    @property
+    def options(self) -> list[str] | None:
+        """
+        default none, only applies to select
+        """
+        return None
+
+
+class Text(FunctionParameter[str]):
+    def __init__(self, *, default: str | None = None) -> None:
+        if default is not None:
+            self.set_default(default)
+
+    def input_type(self) -> InputType:
+        return InputType.TEXT
+
+    def encode(self, value: str) -> str:
+        return value
+
+    def decode(self, value: str) -> str:
+        return value
+
+
+class TextArea(Text):
+    def input_type(self) -> InputType:
+        return InputType.TEXTAREA
+
+
+class Number(FunctionParameter[float]):
+    def __init__(self, *, default: float | None = None) -> None:
+        if default is not None:
+            self.set_default(default)
+
+    def input_type(self) -> InputType:
+        return InputType.NUMBER
+
+    def encode(self, value: float) -> str:
+        return str(value)
+
+    def decode(self, value: str) -> float:
+        return float(value)
+
+
+class Integer(FunctionParameter[int]):
+    def __init__(self, *, default: int | None = None) -> None:
+        if default is not None:
+            self.set_default(default)
+
+    def input_type(self) -> InputType:
+        return InputType.INTEGER
+
+    def encode(self, value: int) -> str:
+        return str(value)
+
+    def decode(self, value: str) -> int:
+        return int(value)
+
+
+class Select(FunctionParameter[str]):
+    """
+    basic select which supports choosing one value from a list of strings
+    """
+
+    def __init__(self, *, options: list[str], default: str | None = None) -> None:
+        self._options = options
+        if default is not None:
+            self.set_default(default)
+
+    def input_type(self) -> InputType:
+        return InputType.SELECT
+
+    def encode(self, value: str) -> str:
+        return value
+
+    def decode(self, value: str) -> str:
+        return value
+
+    @property
+    def options(self) -> list[str]:
+        return self._options

--- a/script_runner/testutils.py
+++ b/script_runner/testutils.py
@@ -7,7 +7,9 @@ from script_runner.function import WrappedFunction
 
 
 def execute_with_context(
-    func: WrappedFunction, mock_context: FunctionContext[Any], args: list[str]
+    func: WrappedFunction,
+    mock_context: FunctionContext[Any],
+    args: list[str],
 ) -> Any:
     """
     Run a function with a mock context, and return the result.

--- a/tests/example/__init__.py
+++ b/tests/example/__init__.py
@@ -2,25 +2,24 @@
 example for tests
 """
 
-from typing import Literal
-
 from script_runner import read, write
+from script_runner.function_parameter import Select, Text
 
 
 @read
-def hello(to: str = "world") -> str:
+def hello(to: Text = Text(default="world")) -> str:
     """
     This function says hello to someone
     """
-    return f"hello {to}"
+    return f"hello {to.value}"
 
 
 @read
-def hello_with_enum(to: Literal["foo", "bar"] = "foo") -> str:
+def hello_with_enum(to: Select = Select(options=["foo", "bar"], default="foo")) -> str:
     """
     Demo of literal type + default value
     """
-    return f"hello {to}"
+    return f"hello {to.value}"
 
 
 @write

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,18 @@
+from script_runner.context import FunctionContext
+from script_runner.testutils import execute_with_context
+from tests.example import hello, hello_with_enum
+
+mock_context = FunctionContext(
+    region="test",
+    group_config=None,
+)
+
+
+def test_simple_function() -> None:
+    result = execute_with_context(hello, mock_context, ["there"])
+    assert result == "hello there"
+
+
+def test_enum() -> None:
+    result = execute_with_context(hello_with_enum, mock_context, ["bar"])
+    assert result == "hello bar"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from script_runner.auth import GoogleAuth, NoAuth
-from script_runner.utils import CommonFields, FunctionParameter, load_group
+from script_runner.utils import CommonFields, FunctionParameter, InputType, load_group
 
 
 def test_common_fields() -> None:
@@ -47,8 +47,19 @@ def test_validate_config_functions() -> None:
         "some_write_function",
     ]
     assert [f.parameters for f in group.functions] == [
-        [FunctionParameter(name="to", default="world", enumValues=None)],
-        [FunctionParameter(name="to", default="foo", enumValues=["foo", "bar"])],
+        [
+            FunctionParameter(
+                name="to", type=InputType.TEXT, default="world", enum_values=None
+            )
+        ],
+        [
+            FunctionParameter(
+                name="to",
+                type=InputType.SELECT,
+                default="foo",
+                enum_values=["foo", "bar"],
+            )
+        ],
         [],
     ]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
 import pytest
 
 from script_runner.auth import GoogleAuth, NoAuth
-from script_runner.utils import CommonFields, FunctionParameter, load_group
 from script_runner.function_parameter import InputType
+from script_runner.utils import CommonFields, FunctionParameter, load_group
 
 
 def test_common_fields() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 import pytest
 
 from script_runner.auth import GoogleAuth, NoAuth
-from script_runner.utils import CommonFields, FunctionParameter, InputType, load_group
+from script_runner.utils import CommonFields, FunctionParameter, load_group
+from script_runner.function_parameter import InputType
 
 
 def test_common_fields() -> None:


### PR DESCRIPTION
this adds the ability for users to customize the
function input types in the UI, as well as support different python types (not just strings) as arguments. now all inputs to script have to a subclass of FunctionParameter and implement its methods

this enables us to define a lot more custom behavior around the inputs. for example we can:
- have numeric types like float and int, with validation on the UI as well
- have custom input types for the same python type. e.g. now there is a regular text input as well as multi-line textarea for longer inputs.
- we can add other stuff in the future such as multiple select and custom autocompletes