### PR TITLE
autocomplete: adding the backend type and api endpoint

### DIFF
--- a/script_runner/__init__.py
+++ b/script_runner/__init__.py
@@ -1,6 +1,7 @@
 from script_runner.context import get_function_context
 from script_runner.function import read, write
 from script_runner.function_parameter import (
+    Autocomplete,
     FunctionParameter,
     Integer,
     Number,
@@ -19,4 +20,5 @@ __all__ = [
     "Number",
     "Integer",
     "Select",
+    "Autocomplete",
 ]

--- a/script_runner/app_blueprint.py
+++ b/script_runner/app_blueprint.py
@@ -300,7 +300,7 @@ if not isinstance(config, MainConfig):
 
     @app_blueprint.route("/autocomplete_region", methods=["POST"])
     @authenticate_request
-    def autocompmlete_one_region() -> Response:
+    def autocomplete_one_region() -> Response:
         """
         Get autocomplete values for one region. Called from the `/autocomplete` endpoint.
         """

--- a/script_runner/app_blueprint.py
+++ b/script_runner/app_blueprint.py
@@ -18,6 +18,7 @@ from flask import (
 
 from script_runner.auth import UnauthorizedUser
 from script_runner.function import WrappedFunction
+from script_runner.function_parameter import Autocomplete
 from script_runner.utils import CombinedConfig, MainConfig, RegionConfig, load_config
 
 config = load_config()
@@ -120,6 +121,47 @@ if not isinstance(config, RegionConfig):
     @cache_static_files
     def static_file(filename: str) -> Response:
         return send_from_directory("frontend/dist/assets", filename)
+
+    @app_blueprint.route("/autocomplete", methods=["POST"])
+    @authenticate_request
+    def autocomplete() -> Response:
+        """
+        Get autocomplete options for a function parameter
+        """
+        assert not isinstance(config, RegionConfig)
+        data = request.get_json()
+        group_name = data["group"]
+        group = config.groups[group_name]
+        requested_function = data["function"]
+        function = next(
+            (f for f in group.functions if f.name == requested_function), None
+        )
+        assert function is not None, "Invalid function"
+
+        results = {}
+
+        for requested_region in data["regions"]:
+            region = next(
+                (r for r in config.main.regions if r.name == requested_region), None
+            )
+            if region is None:
+                err_response = make_response(jsonify({"error": "Invalid region"}), 400)
+                return err_response
+
+            scheme = request.scheme if isinstance(config, CombinedConfig) else "http"
+
+            res = requests.post(
+                f"{scheme}://{region.url}/options_region",
+                json={
+                    "group": group_name,
+                    "function": function.name,
+                    "region": region.name,
+                },
+            )
+            res.raise_for_status()
+            results[region.name] = res.json()
+
+        return make_response(jsonify(results), 200)
 
     @app_blueprint.route("/run", methods=["POST"])
     @authenticate_request
@@ -255,3 +297,34 @@ if not isinstance(config, MainConfig):
         g.region = data["region"]
         g.group_config = group_config
         return make_response(jsonify(func(*params)), 200)
+
+    @app_blueprint.route("/autocomplete_region", methods=["POST"])
+    @authenticate_request
+    def autocompmlete_one_region() -> Response:
+        """
+        Get autocomplete values for one region. Called from the `/autocomplete` endpoint.
+        """
+
+        assert isinstance(config, (RegionConfig, CombinedConfig))
+
+        data = request.get_json()
+        group_name = data["group"]
+        group = config.groups[group_name]
+        requested_function = data["function"]
+
+        options = {}
+
+        module = importlib.import_module(group.module)
+        func = getattr(module, requested_function)
+        assert isinstance(func, WrappedFunction)
+
+        function = next(
+            (f for f in group.functions if f.name == requested_function), None
+        )
+        assert function is not None
+
+        for param in function.parameters:
+            if isinstance(param._ref, Autocomplete):
+                options[param.name] = param._ref.get_autocomplete_options()
+
+        return make_response(jsonify(options), 200)

--- a/script_runner/function_parameter.py
+++ b/script_runner/function_parameter.py
@@ -1,13 +1,14 @@
 from abc import ABC, abstractmethod
-from enum import Enum
-from typing import Generic, TypeVar
+from enum import StrEnum
+from typing import Callable, Generic, TypeVar
 
 
 # This is the list of types that the UI knows how to handle
-class InputType(Enum):
+class InputType(StrEnum):
     TEXT = "text"  # <input type=text />
     TEXTAREA = "textarea"  # <textarea />
     SELECT = "select"  # <select />
+    AUTOCOMPLETE = "autocomplete"  # <input type=text /> with autocomplete
     NUMBER = "number"  # <input type=number />
     INTEGER = "integer"  # <input type=number /> with integer validation
 
@@ -142,3 +143,30 @@ class Select(FunctionParameter[str]):
     @property
     def options(self) -> list[str]:
         return self._options
+
+
+class Autocomplete(FunctionParameter[str]):
+    """
+    select with dynamically generated options
+
+    the options callable gets passed the list of selected regions to autocomplete for
+    """
+
+    def __init__(
+        self, *, options: Callable[[], list[str]], default: str | None = None
+    ) -> None:
+        self._options = options
+        if default is not None:
+            self.set_default(default)
+
+    def input_type(self) -> InputType:
+        return InputType.AUTOCOMPLETE
+
+    def encode(self, value: str) -> str:
+        return value
+
+    def decode(self, value: str) -> str:
+        return value
+
+    def get_autocomplete_options(self) -> list[str]:
+        return self._options()

--- a/script_runner/utils.py
+++ b/script_runner/utils.py
@@ -21,7 +21,10 @@ from script_runner.audit_log import (
 )
 from script_runner.auth import AuthMethod, GoogleAuth, NoAuth
 from script_runner.function import WrappedFunction
-from script_runner.function_parameter import InputType, FunctionParameter as RealFunctionParameter
+from script_runner.function_parameter import FunctionParameter as RealFunctionParameter
+from script_runner.function_parameter import (
+    InputType,
+)
 
 
 class ConfigError(Exception):
@@ -63,7 +66,7 @@ class FunctionParameter:
     type: InputType
     default: str | None
     enum_values: list[str] | None  # applies only to select
-    _ref: RealFunctionParameter
+    _ref: RealFunctionParameter[Any]
 
 
 @dataclass(frozen=True)

--- a/script_runner/utils.py
+++ b/script_runner/utils.py
@@ -21,7 +21,7 @@ from script_runner.audit_log import (
 )
 from script_runner.auth import AuthMethod, GoogleAuth, NoAuth
 from script_runner.function import WrappedFunction
-from script_runner.function_parameter import InputType
+from script_runner.function_parameter import InputType, FunctionParameter as RealFunctionParameter
 
 
 class ConfigError(Exception):
@@ -63,6 +63,7 @@ class FunctionParameter:
     type: InputType
     default: str | None
     enum_values: list[str] | None  # applies only to select
+    _ref: RealFunctionParameter
 
 
 @dataclass(frozen=True)
@@ -258,6 +259,7 @@ def load_group(module_name: str, group: str) -> FunctionGroup:
                         type=p.input_type(),
                         default=p.default,
                         enum_values=p.options,
+                        _ref=p,
                     )
                     for (name, p) in function._params
                 ],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,10 @@
+from unittest.mock import ANY
+
 import pytest
 
 from script_runner.auth import GoogleAuth, NoAuth
 from script_runner.function_parameter import InputType
 from script_runner.utils import CommonFields, FunctionParameter, load_group
-from unittest.mock import ANY
 
 
 def test_common_fields() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import pytest
 from script_runner.auth import GoogleAuth, NoAuth
 from script_runner.function_parameter import InputType
 from script_runner.utils import CommonFields, FunctionParameter, load_group
+from unittest.mock import ANY
 
 
 def test_common_fields() -> None:
@@ -50,7 +51,11 @@ def test_validate_config_functions() -> None:
     assert [f.parameters for f in group.functions] == [
         [
             FunctionParameter(
-                name="to", type=InputType.TEXT, default="world", enum_values=None
+                name="to",
+                type=InputType.TEXT,
+                default="world",
+                enum_values=None,
+                _ref=ANY,
             )
         ],
         [
@@ -59,6 +64,7 @@ def test_validate_config_functions() -> None:
                 type=InputType.SELECT,
                 default="foo",
                 enum_values=["foo", "bar"],
+                _ref=ANY,
             )
         ],
         [],


### PR DESCRIPTION
this is some groundwork on the api side to support autocomplete later
- adds the autocomplete input type
- adds the /autocomplete and /autocomplete_region endpoints which return the autocomplete values for all autocomplete inputs across selected regions for a given function parameter

in the future the UI will have a custom 'autocomplete' component which will call this endpoint and populate a dropdown when it sees an input with this type