### PR TITLE
fix empty headers in /autocomplete endpoint

### DIFF
--- a/script_runner/blueprints/main_config_bp.py
+++ b/script_runner/blueprints/main_config_bp.py
@@ -134,7 +134,6 @@ def autocomplete() -> Response:
                 "region": region.name,
             },
         )
-        res.raise_for_status()
         results[region.name] = res.json()
 
     return make_response(jsonify(results), 200)


### PR DESCRIPTION
this line was causing the proper response headers to go missing even when we get 200 responses

the `/autocomplete` endpoint could not be loaded since it was missing proper `content-type` and other headers

this wasn't noticable in dev since devserver is less strict than gunicorn