### PR TITLE
fix autocomplete

### DIFF
--- a/script_runner/blueprints/main_config_bp.py
+++ b/script_runner/blueprints/main_config_bp.py
@@ -99,7 +99,6 @@ def run_all() -> Response:
 
 
 @main_config_bp.route("/autocomplete", methods=["GET"])
-@authenticate_request
 @cache_autocomplete
 def autocomplete() -> Response:
     """

--- a/script_runner/blueprints/region_config_bp.py
+++ b/script_runner/blueprints/region_config_bp.py
@@ -51,7 +51,6 @@ def run_one_region() -> Response:
 
 
 @region_config_bp.route("/autocomplete_region", methods=["GET"])
-@authenticate_request
 def autocomplete_one_region() -> Response:
     """
     Get autocomplete values for one region. Called from the `/autocomplete` endpoint.


### PR DESCRIPTION
remove the `@authenticate` decorator from autocomplete

this fixes a `415 (Unsupported media type)` error on the autocomplete endpoint. this occurs because the authenticate decorator only works with run / post requests. this is a GET request now (for caching reasons).

we don't really need to verify a user is in the right group to allow autocomplete or any other endpoints in this application, it's only required on run.