### PR TITLE
autocomplete: ui improvements

### DIFF
--- a/script_runner/frontend/src/Script.tsx
+++ b/script_runner/frontend/src/Script.tsx
@@ -60,7 +60,7 @@ function Script(props: Props) {
         setDynamicOptions(options);
       });
     }
-  }, [parameters, props.group, props.function, props.api]);
+  }, [parameters, props.group, props.function, props.api, props.regions]);
 
   function handleInputChange(idx: number, value: string) {
     setParams((prev) => {

--- a/script_runner/frontend/src/api.tsx
+++ b/script_runner/frontend/src/api.tsx
@@ -33,6 +33,10 @@ class Api {
   async getAutocompleteOptions(data: { group: string, function: string, regions: string[] }): Promise<OptionResult> {
     const { group, function: functionName, regions } = data;
 
+    if (regions.length === 0) {
+      return {};
+    }
+
     const searchParams = new URLSearchParams({
       group,
       function: functionName,


### PR DESCRIPTION
if the selected region changes, we need to reload the list of autocomplete options otherwise we are showing the stale ones

if no region is selected, don't call the API, immediately return an empty autocomplete list