### PR TITLE
fix: Fix circular dependency

### DIFF
--- a/script_runner/app.py
+++ b/script_runner/app.py
@@ -2,9 +2,11 @@ import sentry_sdk
 from flask import Flask
 
 from script_runner.blueprints.base_app_bp import base_app_bp
-from script_runner.utils import CombinedConfig, MainConfig, RegionConfig, load_config
-
-config = load_config()
+from script_runner.utils import CombinedConfig, MainConfig, RegionConfig
+from script_runner.blueprints.static_routes_bp import static_files_bp
+from script_runner.blueprints.main_config_bp import main_config_bp
+from script_runner.blueprints.region_config_bp import region_config_bp
+from script_runner.config import config
 
 if config.sentry_dsn:
     sentry_sdk.init(
@@ -15,16 +17,10 @@ app = Flask(__name__)
 app.register_blueprint(base_app_bp)
 
 if isinstance(config, (MainConfig, CombinedConfig)):
-    from script_runner.blueprints.static_routes_bp import static_files_bp
-
     app.register_blueprint(static_files_bp)
 
 if isinstance(config, (MainConfig, CombinedConfig)):
-    from script_runner.blueprints.main_config_bp import main_config_bp
-
     app.register_blueprint(main_config_bp)
 
 if isinstance(config, (RegionConfig, CombinedConfig)):
-    from script_runner.blueprints.region_config_bp import region_config_bp
-
     app.register_blueprint(region_config_bp)

--- a/script_runner/app.py
+++ b/script_runner/app.py
@@ -2,11 +2,11 @@ import sentry_sdk
 from flask import Flask
 
 from script_runner.blueprints.base_app_bp import base_app_bp
-from script_runner.utils import CombinedConfig, MainConfig, RegionConfig
-from script_runner.blueprints.static_routes_bp import static_files_bp
 from script_runner.blueprints.main_config_bp import main_config_bp
 from script_runner.blueprints.region_config_bp import region_config_bp
+from script_runner.blueprints.static_routes_bp import static_files_bp
 from script_runner.config import config
+from script_runner.utils import CombinedConfig, MainConfig, RegionConfig
 
 if config.sentry_dsn:
     sentry_sdk.init(

--- a/script_runner/blueprints/main_config_bp.py
+++ b/script_runner/blueprints/main_config_bp.py
@@ -9,13 +9,13 @@ from flask import (
     request,
 )
 
-from script_runner.app import config
 from script_runner.decorators import (
     authenticate_request,
     cache_autocomplete,
     get_config,
 )
 from script_runner.utils import CombinedConfig, RegionConfig
+from script_runner.config import config
 
 main_config_bp: Blueprint = Blueprint("main_config", __name__)
 

--- a/script_runner/blueprints/main_config_bp.py
+++ b/script_runner/blueprints/main_config_bp.py
@@ -9,13 +9,13 @@ from flask import (
     request,
 )
 
+from script_runner.config import config
 from script_runner.decorators import (
     authenticate_request,
     cache_autocomplete,
     get_config,
 )
 from script_runner.utils import CombinedConfig, RegionConfig
-from script_runner.config import config
 
 main_config_bp: Blueprint = Blueprint("main_config", __name__)
 

--- a/script_runner/blueprints/region_config_bp.py
+++ b/script_runner/blueprints/region_config_bp.py
@@ -9,7 +9,7 @@ from flask import (
     request,
 )
 
-from script_runner.app import config
+from script_runner.config import config
 from script_runner.decorators import authenticate_request
 from script_runner.function import WrappedFunction
 from script_runner.function_parameter import DynamicAutocomplete

--- a/script_runner/config.py
+++ b/script_runner/config.py
@@ -1,0 +1,3 @@
+from script_runner.utils import load_config
+
+config = load_config()

--- a/script_runner/decorators.py
+++ b/script_runner/decorators.py
@@ -5,7 +5,7 @@ from typing import Any, Callable
 
 from flask import Response, jsonify, make_response, request
 
-from script_runner.app import config
+from script_runner.config import config
 from script_runner.auth import UnauthorizedUser
 from script_runner.utils import CombinedConfig, MainConfig
 

--- a/script_runner/decorators.py
+++ b/script_runner/decorators.py
@@ -5,8 +5,8 @@ from typing import Any, Callable
 
 from flask import Response, jsonify, make_response, request
 
-from script_runner.config import config
 from script_runner.auth import UnauthorizedUser
+from script_runner.config import config
 from script_runner.utils import CombinedConfig, MainConfig
 
 


### PR DESCRIPTION
previously the decorators and blueprint files were importing app.py, and app.py was also importing the decorators and blueprint files. delayed imports was being used to get around it, but this is a workaround that really shouldn't be needed.

since app.py is the top level of the flask application, no one else should be importing it.