### PR TITLE
move the get_config function

### DIFF
--- a/script_runner/decorators.py
+++ b/script_runner/decorators.py
@@ -1,4 +1,3 @@
-import functools
 import logging
 from functools import wraps
 from typing import Any, Callable
@@ -45,47 +44,3 @@ def cache_autocomplete(f: Callable[..., Response]) -> Callable[..., Response]:
         return res
 
     return add_cache_headers
-
-
-@functools.lru_cache(maxsize=1)
-def get_config() -> dict[str, Any]:
-    assert isinstance(config, (MainConfig, CombinedConfig))
-
-    regions = config.main.regions
-    groups = config.groups
-
-    group_data = [
-        {
-            "group": g,
-            "functions": [
-                {
-                    "name": f.name,
-                    "docstring": f.docstring,
-                    "source": f.source,
-                    "parameters": [
-                        {
-                            "name": p.name,
-                            "type": p.type.value,
-                            "default": p.default,
-                            "enumValues": p.enum_values,
-                        }
-                        for p in f.parameters
-                    ],
-                    "isReadonly": f.is_readonly,
-                }
-                for f in function_group.functions
-            ],
-            "docstring": function_group.docstring,
-            "markdownFiles": [
-                {"name": file.filename, "content": file.content}
-                for file in function_group.markdown_files
-            ],
-        }
-        for (g, function_group) in groups.items()
-    ]
-
-    return {
-        "title": config.main.title,
-        "regions": [r.name for r in regions],
-        "groups": group_data,
-    }

--- a/script_runner/decorators.py
+++ b/script_runner/decorators.py
@@ -6,7 +6,6 @@ from flask import Response, jsonify, make_response, request
 
 from script_runner.auth import UnauthorizedUser
 from script_runner.config import config
-from script_runner.utils import CombinedConfig, MainConfig
 
 
 def authenticate_request(f: Callable[..., Response]) -> Callable[..., Response]:


### PR DESCRIPTION
- this function isn't a decorator so it's a bit confusing that it was in the decorators.py file
- since it only exists to cache part of the `/config` api response, let's put it next to that api definition