### PR TITLE
dynamic page title

### DIFF
--- a/script_runner/frontend/src/App.tsx
+++ b/script_runner/frontend/src/App.tsx
@@ -36,6 +36,9 @@ function App() {
     api.getConfig()
       .then((data: Config) => {
         setConfig(data);
+        if (data.title) {
+          document.title = data.title;
+        }
       })
       .then(() => {
         parseHashAndSetRoute();

--- a/script_runner/frontend/src/Header.tsx
+++ b/script_runner/frontend/src/Header.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
 
 interface Props {
-  title: string;
+  title: string | null;
   regions: string[];
   route: Route;
   navigate: (to: Route) => void;

--- a/script_runner/frontend/src/types.tsx
+++ b/script_runner/frontend/src/types.tsx
@@ -49,7 +49,7 @@ export interface ConfigGroup {
 }
 
 export interface Config {
-  title: string;
+  title: string | null;
   regions: string[];
   groups: ConfigGroup[];
   groupsWithoutAccess: string[];


### PR DESCRIPTION
if the user sets the app name via config, we also use it for the html page title

also fixes the type of the `title` in config which is actually nullable