### PR TITLE
fix autocomplete z-index (for real this time)

### DIFF
--- a/script_runner/frontend/src/App.css
+++ b/script_runner/frontend/src/App.css
@@ -283,12 +283,12 @@ li.home-search-result:hover {
   background-color: white;
   top: 22px;
   box-sizing: border-box;
+  z-index: 1000;
 }
 
 .autocomplete-list a {
   padding: 4px 8px;
   display: block;
-  z-index: 1000;
 }
 
 .autocomplete-list a.active {


### PR DESCRIPTION
fixes this bug where the dropdown is behind the input

<img width="1624" alt="Screenshot 2025-05-20 at 7 59 56 pm" src="https://github.com/user-attachments/assets/9c203e6d-3f60-4422-987b-986f27ad2cc3" />

- z-index should be set on the whole dropdown list not the nested anchors to actually work
