### PR TITLE
split up the script result component

### DIFF
--- a/script_runner/frontend/src/results/Chart.tsx
+++ b/script_runner/frontend/src/results/Chart.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { AgCharts } from 'ag-charts-react';
-import { MergedRowData } from './types';
+import { MergedRowData } from '../types';
 
 type ChartData = {
   data: unknown[],
@@ -74,6 +74,8 @@ function getNumericFields(data: MergedRowData[]): string[] {
 type Props = {
   data: MergedRowData[] | null;
   regions: string[];
+  // ignore other unused props, these should be aligned across all components later
+  [key: string]: any;
 }
 
 function Chart(props: Props) {
@@ -119,7 +121,7 @@ function Chart(props: Props) {
     </div >
   } else {
     return <div className="function-result-chart">
-      <p className="no-data">data can't be displayed as a chart</p>
+      <p className="no-data">No data suitable for chart view.</p>
     </div>
   }
 

--- a/script_runner/frontend/src/results/Chart.tsx
+++ b/script_runner/frontend/src/results/Chart.tsx
@@ -75,7 +75,7 @@ type Props = {
   data: MergedRowData[] | null;
   regions: string[];
   // ignore other unused props, these should be aligned across all components later
-  [key: string]: any;
+  [key: string]: any;  // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 function Chart(props: Props) {

--- a/script_runner/frontend/src/results/Download.tsx
+++ b/script_runner/frontend/src/results/Download.tsx
@@ -1,0 +1,39 @@
+type Props = {
+  group: string;
+  function: string;
+  filteredResults: unknown;
+  // ignore other unused props, these should be aligned across all components later
+  [key: string]: any;
+}
+
+function Download(props: Props) {
+
+  function download() {
+    const blob = new Blob([JSON.stringify(props.filteredResults)], { type: 'application/json' });
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '');
+    const fileName = `${props.group}_${props.function}_${timestamp}.json`
+    const link = document.createElement('a');
+    link.download = fileName;
+    link.href = URL.createObjectURL(blob);
+    link.click();
+    URL.revokeObjectURL(link.href);
+  }
+
+  function copy() {
+    // Copy the entire props.data (results and errors)
+    const dataToCopy = props.filteredResults ? JSON.stringify(props.filteredResults, null, 2) : "No data";
+    navigator.clipboard.writeText(dataToCopy)
+      .then(() => console.log("Copied to clipboard!"))
+      .catch(err => console.error("Failed to copy to clipboard:", err));
+  }
+
+  return (
+    <div className="function-result-download">
+      <div><button onClick={download}>download all data (results & errors)</button></div>
+      <div><button onClick={copy}>copy all data to clipboard</button></div>
+    </div>
+  );
+}
+
+export default Download;
+

--- a/script_runner/frontend/src/results/Download.tsx
+++ b/script_runner/frontend/src/results/Download.tsx
@@ -3,7 +3,7 @@ type Props = {
   function: string;
   filteredResults: unknown;
   // ignore other unused props, these should be aligned across all components later
-  [key: string]: any;
+  [key: string]: any;  // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 function Download(props: Props) {

--- a/script_runner/frontend/src/results/Grid.tsx
+++ b/script_runner/frontend/src/results/Grid.tsx
@@ -1,0 +1,52 @@
+import { AgGridReact } from 'ag-grid-react';
+import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community';
+import { MergedRowData, RowData } from '../types';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+type Props = {
+  data: MergedRowData[] | null;
+  // ignore other unused props, these should be aligned across all components later
+  [key: string]: any;
+}
+
+function Grid(props: Props) {
+  const gridData = getGridData(props.data);
+
+  if (!gridData) {
+    return <p>No data suitable for grid view.</p>;
+  }
+
+
+  const colDefs = gridData.columns.map(f => ({ "field": f, headerName: f }));
+  const rowData = gridData.data as RowData[];
+
+  return <div className="ag-theme-alpine" style={{ height: '500px', width: '100%' }}>
+    <AgGridReact
+      rowData={rowData}
+      columnDefs={colDefs}
+      defaultColDef={{ sortable: true, resizable: true, filter: true, flex: 1 }}
+    />
+  </div>
+}
+
+
+// returns table formatted data if data is table like
+// otherwise return null
+function getGridData(mergedData: MergedRowData[] | null) {
+  if (Array.isArray(mergedData) && mergedData.every(row => typeof row === 'object' && row !== null)) {
+    if (mergedData.length === 0) {
+      return null;
+    }
+
+    return {
+      columns: Object.keys(mergedData[0]),
+      data: mergedData,
+    };
+  }
+
+  return null;
+}
+
+
+export default Grid;

--- a/script_runner/frontend/src/results/Grid.tsx
+++ b/script_runner/frontend/src/results/Grid.tsx
@@ -7,7 +7,7 @@ ModuleRegistry.registerModules([AllCommunityModule]);
 type Props = {
   data: MergedRowData[] | null;
   // ignore other unused props, these should be aligned across all components later
-  [key: string]: any;
+  [key: string]: any;  // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 function Grid(props: Props) {

--- a/script_runner/frontend/src/results/Json.tsx
+++ b/script_runner/frontend/src/results/Json.tsx
@@ -1,0 +1,20 @@
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { coy } from 'react-syntax-highlighter/dist/esm/styles/prism';
+
+
+type Props = {
+  filteredResults: unknown;
+  // ignore other unused props, these should be aligned across all components later
+  [key: string]: any;
+}
+
+
+function Json(props: Props) {
+  return <div className="json-viewer">
+    <SyntaxHighlighter language="json" style={coy} customStyle={{ fontSize: 12, width: "100%" }} wrapLines={true} lineProps={{ style: { whiteSpace: 'pre-wrap' } }}>
+      {JSON.stringify(props.filteredResults, null, 2)}
+    </SyntaxHighlighter>
+  </div>
+}
+
+export default Json;

--- a/script_runner/frontend/src/results/Json.tsx
+++ b/script_runner/frontend/src/results/Json.tsx
@@ -5,7 +5,7 @@ import { coy } from 'react-syntax-highlighter/dist/esm/styles/prism';
 type Props = {
   filteredResults: unknown;
   // ignore other unused props, these should be aligned across all components later
-  [key: string]: any;
+  [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 


### PR DESCRIPTION
this is the first step to implementing a standard interface for react components that display results of script executions.

this will enable them to be customizable in the future, so users can contribute their own custom visualizations.

there are no functional changes or improvements here (that will come later) - this pr just shifts code mostly as-is from a single big ScriptResult component with lots of nested conditions to dedicated components for each visualization which all get passed the exact same props.