### PR TITLE
chore(deps): bump black from 25.1.0 to 26.3.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest==8.3.5
 flake8==7.1.2
-black==25.1.0
+black==26.3.1
 isort==6.0.1
 mypy==1.15.0
 types-requests==2.32.0.20250306

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -10,17 +10,17 @@ mock_context = FunctionContext(
 
 
 def test_simple_function() -> None:
-    (result, _) = execute_with_context(hello, mock_context, ["there"])
+    result, _ = execute_with_context(hello, mock_context, ["there"])
     assert result == "hello there"
 
 
 def test_basic_autocomplete() -> None:
-    (result, _) = execute_with_context(basic_autocomplete, mock_context, ["bar"])
+    result, _ = execute_with_context(basic_autocomplete, mock_context, ["bar"])
     assert result == "hello bar"
 
 
 def test_dynamic_autocomplete() -> None:
-    (result, autocompletions) = execute_with_context(
+    result, autocompletions = execute_with_context(
         dynamic_autocomplete, mock_context, ["foo"]
     )
     assert result == "Selected foo"


### PR DESCRIPTION
## Summary
- Resolves [GHSA-3936-cmfr-pm3m](https://github.com/advisories/GHSA-3936-cmfr-pm3m) (high — arbitrary file writes from unsanitized user input in the cache file name; affects `black <26.3.1`).
- Includes the only formatting change black 26 introduces in this repo: dropping redundant parens around single-target tuple unpackings in `tests/test_example.py`.

Resolves [INFRENG-285](https://linear.app/getsentry/issue/INFRENG-285/black-vulnerability-in-getsentryscript-runner).

## Test plan
- [x] `black script_runner tests --check` passes locally with 26.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)