### PR TITLE
meta: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @getsentry/ops
+* @getsentry/sre


### PR DESCRIPTION
the github teams were re-arranged recently

@getsentry/sre covers infraeng, prodeng and sre