### PR TITLE
fix: Avoid mutating cached config in /config endpoint

### DIFF
--- a/script_runner/blueprints/main_bp.py
+++ b/script_runner/blueprints/main_bp.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import logging
 from typing import Any
@@ -189,7 +190,9 @@ def create_main_bp(app_config: Config) -> Blueprint:
 
     @main_config_bp.route("/config")
     def fetch_config() -> Response:
-        res = get_config()
+        # Copy the cached config: mutating the shared cached dict would hide
+        # groups from all subsequent requests in this process.
+        res = copy.deepcopy(get_config())
 
         groups_without_access = []
 

--- a/tests/blueprints/test_main_config_bp.py
+++ b/tests/blueprints/test_main_config_bp.py
@@ -1,10 +1,11 @@
-from unittest.mock import ANY
+from unittest.mock import ANY, patch
 
 import pytest
 from flask import Flask
 
 from script_runner.app import create_flask_app
 from script_runner.approval_policy import AllowAll
+from script_runner.auth import NoAuth
 
 
 @pytest.fixture(
@@ -37,5 +38,28 @@ def test_config(app: Flask) -> None:
     assert response.json["groups"] == [
         {"group": "example", "docstring": ANY, "functions": ANY, "markdownFiles": [ANY]}
     ]
+    assert response.json["groupsWithoutAccess"] == []
+    assert response.json["accessMap"]["example"]["hello"] == {"local": "allow"}
+
+
+def test_config_not_poisoned_by_restricted_user(app: Flask) -> None:
+    """
+    A request from a user without group access must not remove those groups
+    from the cached config served to subsequent requests.
+    """
+    test_client = app.test_client()
+
+    with patch.object(NoAuth, "has_group_access", return_value=False):
+        restricted = test_client.get("config")
+    assert restricted.status_code == 200
+    assert restricted.json is not None
+    assert restricted.json["groups"] == []
+    assert restricted.json["groupsWithoutAccess"] == ["example"]
+    assert restricted.json["accessMap"] == {}
+
+    response = test_client.get("config")
+    assert response.status_code == 200
+    assert response.json is not None
+    assert [g["group"] for g in response.json["groups"]] == ["example"]
     assert response.json["groupsWithoutAccess"] == []
     assert response.json["accessMap"]["example"]["hello"] == {"local": "allow"}


### PR DESCRIPTION
fetch_config wrote per-user fields into the lru_cached dict, so one restricted user's request hid groups from everyone until the next deploy. we now deep-copy the cached config before filtering (INFRENG-61).