### PR TITLE
fix(testutils): set g.user in execute_with_context

### DIFF
--- a/script_runner/testutils.py
+++ b/script_runner/testutils.py
@@ -19,6 +19,7 @@ def execute_with_context(
     """
     app = Flask(__name__)
     with app.app_context():
+        g.user = mock_context.user
         g.region = mock_context.region
         g.group_config = mock_context.group_config
 


### PR DESCRIPTION
get_function_context() reads g.user since the audit-logging change change in https://github.com/getsentry/script-runner/pull/104 but the test harness never set it so every downstream test using execute_with_context failed with AttributeError: user.