### PR TITLE
fix: set g.user before running the wrapped function

### DIFF
--- a/script_runner/context.py
+++ b/script_runner/context.py
@@ -8,7 +8,9 @@ T = TypeVar("T")
 
 @dataclass(frozen=True)
 class FunctionContext(Generic[T]):
-    user: str
+    # user is unset on endpoints that don't authenticate (e.g. region-side
+    # autocomplete) and under no_auth, so it may be None.
+    user: str | None
     region: str
     group_config: T
 
@@ -19,7 +21,7 @@ def get_function_context() -> FunctionContext[T]:
     This is used to access the region and group config.
     """
     return FunctionContext(
-        user=g.user,
+        user=g.get("user"),
         region=g.region,
         group_config=g.group_config,
     )

--- a/script_runner/decorators.py
+++ b/script_runner/decorators.py
@@ -17,9 +17,10 @@ def authenticate_request(
             try:
                 config = app_config.config
                 config.auth.authenticate_request(request)
+                # Set g.user before running the wrapped function so it is
+                # available via get_function_context() during execution.
+                g.user = config.auth.get_user_email(request)
                 res = f(*args, **kwargs)
-                user_email = config.auth.get_user_email(request)
-                g.user = user_email
                 return res
             except UnauthorizedUser as e:
                 logging.error(e, exc_info=True)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,32 @@
+from typing import Any
+
+from flask import Flask, g
+
+from script_runner.context import FunctionContext, get_function_context
+
+
+def test_get_function_context_without_user() -> None:
+    # Endpoints like /autocomplete_region don't authenticate and never set
+    # g.user. get_function_context() must not raise in that case.
+    app = Flask(__name__)
+    with app.app_context():
+        g.region = "test"
+        g.group_config = {"clusters": []}
+
+        context: FunctionContext[Any] = get_function_context()
+
+        assert context.user is None
+        assert context.region == "test"
+        assert context.group_config == {"clusters": []}
+
+
+def test_get_function_context_with_user() -> None:
+    app = Flask(__name__)
+    with app.app_context():
+        g.user = "test@test.com"
+        g.region = "test"
+        g.group_config = None
+
+        context: FunctionContext[Any] = get_function_context()
+
+        assert context.user == "test@test.com"

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,11 +1,12 @@
 from dataclasses import replace
 
 import pytest
-from flask import Flask, Request, Response, jsonify, make_response
+from flask import Flask, Request, Response, g, jsonify, make_response
 
 from script_runner.approval_policy import AllowAll
 from script_runner.auth import AuthMethod, UnauthorizedUser
 from script_runner.config import configure
+from script_runner.context import get_function_context
 
 
 class MockAuthMethod(AuthMethod):
@@ -60,6 +61,15 @@ def app() -> Flask:
     def _protected_view() -> Response:
         return make_response(jsonify(message="Access Granted"), 200)
 
+    @app.route("/context_route", methods=["POST"])
+    @authenticate_request(app_config_with_auth_mock)
+    def _context_view() -> Response:
+        # Scripts read the context while the wrapped function runs, so g.user
+        # must already be set by the decorator at this point.
+        g.region = "test"
+        g.group_config = None
+        return make_response(jsonify(user=get_function_context().user), 200)
+
     return app
 
 
@@ -77,3 +87,13 @@ def test_no_auth_on_failure(app: Flask) -> None:
 
     assert response.status_code == 401
     assert response.get_json()["error"] == "Unauthorized"
+
+
+def test_context_available_during_execution(app: Flask) -> None:
+    # Regression: g.user must be set before the wrapped function runs, otherwise
+    # get_function_context() raises AttributeError and the request 500s.
+    with app.test_client() as client:
+        response = client.post("/context_route", json={"group": "test_group"})
+
+    assert response.status_code == 200
+    assert response.get_json()["user"] == "test@test.com"


### PR DESCRIPTION
get_function_context() reads g.user, but the authenticate_request decorator set it only after the wrapped view returned. Any script or autocomplete resolver that called get_function_context() during execution hit AttributeError -> HTTP 500 (all regions, all groups).

Set g.user before invoking the wrapped function, and make get_function_context() tolerate an unset user (g.get -> None) so decorator-less endpoints like /autocomplete_region work too. user is now typed str | None to reflect no_auth/region deployments.

Add regression tests that fail without this change (they reproduce the AttributeError). Existing tests passed because execute_with_context always pre-set g.user, masking the bug.